### PR TITLE
Mount on boot

### DIFF
--- a/amazon_linux.json
+++ b/amazon_linux.json
@@ -102,6 +102,9 @@
               },
               "03mountFS": {
                 "command": "/bin/mount /dev/xvdj /var/lib/neo4j"
+              },
+              "04mountOnReboot": {
+                "command": "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' > /etc/fstab"
               }
             }
           },

--- a/amazon_linux.json
+++ b/amazon_linux.json
@@ -104,7 +104,7 @@
                 "command": "/bin/mount /dev/xvdj /var/lib/neo4j"
               },
               "04mountOnReboot": {
-                "command": "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' > /etc/fstab"
+                "command": "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' >> /etc/fstab"
               }
             }
           },

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -89,6 +89,7 @@
                         "mkdir -p /var/lib/neo4j\n",
                         "mkfs.ext4 /dev/xvdj\n",
                         "mount /dev/xvdj /var/lib/neo4j\n",
+                        "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' > /etc/fstab\n",
                         "wget -O - http://debian.neo4j.org/neotechnology.gpg.key| apt-key add -\n",
                         "echo 'deb http://debian.neo4j.org/repo stable/' > /etc/apt/sources.list.d/neo4j.list\n",
                         "apt-get update -y\n",

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -89,7 +89,7 @@
                         "mkdir -p /var/lib/neo4j\n",
                         "mkfs.ext4 /dev/xvdj\n",
                         "mount /dev/xvdj /var/lib/neo4j\n",
-                        "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' > /etc/fstab\n",
+                        "echo '/dev/xvdj /var/lib/neo4j auto defaults 0 0' >> /etc/fstab\n",
                         "wget -O - http://debian.neo4j.org/neotechnology.gpg.key| apt-key add -\n",
                         "echo 'deb http://debian.neo4j.org/repo stable/' > /etc/apt/sources.list.d/neo4j.list\n",
                         "apt-get update -y\n",


### PR DESCRIPTION
## Description
This pull should fix https://github.com/neo4j-contrib/ec2neo/issues/17 with regard to the neo4j installation not starting upon a reboot. The `/dev/xvdj` was not mounted upon reboot, so it was added to `/etc/fstab` so that it is able to start.

I tested this for both `ubuntu.json` as well as `amazon_linux.json` and both worked. The caveat, however, with the `amazon_linux.json` is that the `haproxy` services seems to require a manual `restart` upon reboot; I figured that issue can maybe be addressed elsewhere.

As always, feedback welcome.