### PR TITLE
use the AWS::EC2::KeyPair::KeyName type for the SSH key

### DIFF
--- a/amazon_linux.json
+++ b/amazon_linux.json
@@ -7,11 +7,7 @@
 
     "SSHKeyName": {
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instances",
-      "Type": "String",
-      "MinLength": "1",
-      "MaxLength": "255",
-      "AllowedPattern" : "[\\x20-\\x7E]*",
-      "ConstraintDescription" : "can contain only ASCII characters."
+      "Type": "AWS::EC2::KeyPair::KeyName"
     },
 
     "InstanceType" : {

--- a/ubuntu.json
+++ b/ubuntu.json
@@ -27,9 +27,10 @@
         "ConstraintDescription" : "Must be a valid EC2 instance type."
       },
 
+
       "SSHKeyName": {
-          "Description": "Name of the SSH key that you will use to access the server (must be on AWS Availability Zone already)",
-          "Type": "String"
+        "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instances",
+        "Type": "AWS::EC2::KeyPair::KeyName"
       },
 
         "NetworkWhitelist": {


### PR DESCRIPTION
## Description
This modifies the `SSHKeyName` parameter's type to be `AWS::EC2::KeyPair::KeyName` so that you can choose from existing keys in your availability zone when you're creating the template.