### PR TITLE
Added HVM64 AMI for eu-west-1

### DIFF
--- a/amazon_linux.json
+++ b/amazon_linux.json
@@ -70,7 +70,7 @@
       "us-east-1"      : { "32" : "ami-31814f58", "64" : "ami-1b814f72", "HVM64" : "ami-0da96764" },
       "us-west-2"      : { "32" : "ami-38fe7308", "64" : "ami-30fe7300", "HVM64" : "NOT_YET_SUPPORTED" },
       "us-west-1"      : { "32" : "ami-11d68a54", "64" : "ami-1bd68a5e", "HVM64" : "NOT_YET_SUPPORTED" },
-      "eu-west-1"      : { "32" : "ami-973b06e3", "64" : "ami-953b06e1", "HVM64" : "NOT_YET_SUPPORTED" },
+      "eu-west-1"      : { "32" : "ami-973b06e3", "64" : "ami-953b06e1", "HVM64" : "ami-6a900219" },
       "ap-southeast-1" : { "32" : "ami-b4b0cae6", "64" : "ami-beb0caec", "HVM64" : "NOT_YET_SUPPORTED" },
       "ap-southeast-2" : { "32" : "ami-b3990e89", "64" : "ami-bd990e87", "HVM64" : "NOT_YET_SUPPORTED" },
       "ap-northeast-1" : { "32" : "ami-0644f007", "64" : "ami-0a44f00b", "HVM64" : "NOT_YET_SUPPORTED" },


### PR DESCRIPTION
AMI ID: ami-6a900219
AMI Name: amzn-ami-hvm-2016.03.2.x86_64-ebs
Source: amazon/amzn-ami-hvm-2016.03.2.x86_64-ebs
Creation date: June 4, 2016 at 1:21:40 AM UTC+2
Platform: Amazon Linux
Architecture: x86_64
Image Type: machine
Virtualization type: hvm
Description: Amazon Linux AMI 2016.03.2 x86_64 HVM EBS
Root Device Name: /dev/xvda
Root Device Type: ebs